### PR TITLE
backend: hwcomposer: implement a real rendering loop syncronized to the nearest vsync

### DIFF
--- a/backend/hwcomposer/backend.c
+++ b/backend/hwcomposer/backend.c
@@ -13,7 +13,7 @@ static bool backend_start(struct wlr_backend *wlr_backend) {
 
 	struct wlr_hwcomposer_output *output;
 	wl_list_for_each(output, &backend->outputs, link) {
-		wl_event_source_timer_update(output->frame_timer, output->frame_delay);
+		wl_event_source_timer_update(output->vsync_timer, output->frame_delay);
 		wlr_output_update_enabled(&output->wlr_output, true);
 		wlr_signal_emit_safe(&backend->backend.events.new_output,
 			&output->wlr_output);

--- a/backend/hwcomposer/hwcomposer2.c
+++ b/backend/hwcomposer/hwcomposer2.c
@@ -25,7 +25,9 @@ void hwcomposer2_vsync_callback(HWC2EventListener* listener, int32_t sequence_id
 		hwc2_display_t display, int64_t timestamp)
 {
 	struct wlr_hwcomposer_backend *hwc = ((hwc_procs_v20 *)listener)->hwc;
-	hwcomposer_vsync_wake(hwc);
+
+	// FIXME: This will cause issues with multiple displays
+	hwc->hwc_vsync_last_timestamp = timestamp;
 }
 
 void hwcomposer2_hotplug_callback(HWC2EventListener* listener, int32_t sequence_id,
@@ -80,7 +82,9 @@ bool hwcomposer2_api_init(struct wlr_hwcomposer_backend *hwc)
 
 	hwc->hwc_width = config->width;
 	hwc->hwc_height = config->height;
-	hwc->hwc_refresh = (config->vsyncPeriod == 0) ? 60000 : 10E11 / config->vsyncPeriod;
+	hwc->hwc_refresh = config->vsyncPeriod;
+	hwc->hwc_refresh = (config->vsyncPeriod == 0) ?
+		(1000000000000LL / HWCOMPOSER_DEFAULT_REFRESH) : config->vsyncPeriod;
 	wlr_log(WLR_INFO, "width: %i height: %i Refresh: %i\n", config->width, config->height, hwc->hwc_refresh);
 
 	hwc2_compat_layer_t* layer = hwc->hwc2_primary_layer =
@@ -103,7 +107,6 @@ void hwcomposer2_present(void *user_data, struct ANativeWindow *window,
 		struct ANativeWindowBuffer *buffer)
 {
 	struct wlr_hwcomposer_backend *hwc = (struct wlr_hwcomposer_backend *)user_data;
-	hwcomposer_vsync_wait(hwc);
 	static int last_present_fence = -1;
 
 	uint32_t num_types = 0;

--- a/include/backend/hwcomposer.h
+++ b/include/backend/hwcomposer.h
@@ -4,8 +4,6 @@
 #include <wlr/backend/hwcomposer.h>
 #include <wlr/backend/interface.h>
 
-#include <pthread.h>
-
 #include <hardware/hardware.h>
 #include <hardware/hwcomposer.h>
 
@@ -32,10 +30,16 @@ struct wlr_hwcomposer_backend {
 	uint32_t hwc_version;
 	int hwc_width;
 	int hwc_height;
-	int hwc_refresh;
+	int64_t hwc_refresh;
 	bool hwc_vsync_enabled;
-	pthread_mutex_t hwc_vsync_mutex;
-	pthread_cond_t hwc_vsync_wait_condition;
+
+	int64_t idle_time; // nsec
+
+	// FIXME: Store the last vsync event timestamp. This really
+	// belongs to wlr_hwcomposer_output, but for simplicity's sake
+	// until we support multiple outputs we'll keep it here.
+	int64_t hwc_vsync_last_timestamp;
+	// TODO: Also store 'vsyncPeriodNanos' if vsync2_4 is supported
 
 #ifdef HWC_DEVICE_API_VERSION_2_0
 	hwc2_compat_device_t* hwc2_device;
@@ -53,8 +57,10 @@ struct wlr_hwcomposer_output {
 	struct ANativeWindow *egl_window;
 	void *egl_display;
 	void *egl_surface;
-	struct wl_event_source *frame_timer;
+	struct wl_event_source *vsync_timer;
 	int frame_delay; // ms
+	int vsync_timer_fd;
+	struct wl_event_source *vsync_event;
 };
 
 void hwcomposer_vsync_control(struct wlr_hwcomposer_backend *hwc, bool enable);

--- a/include/util/time.h
+++ b/include/util/time.h
@@ -14,6 +14,11 @@ uint32_t get_current_time_msec(void);
 int64_t timespec_to_msec(const struct timespec *a);
 
 /**
+ * Convert nanoseconds to a timespec.
+ */
+void timespec_from_nsec(struct timespec *r, int64_t nsec);
+
+/**
  * Subtracts timespec `b` from timespec `a`, and stores the difference in `r`.
  */
 void timespec_sub(struct timespec *r, const struct timespec *a,

--- a/util/time.c
+++ b/util/time.c
@@ -10,6 +10,11 @@ int64_t timespec_to_msec(const struct timespec *a) {
 	return (int64_t)a->tv_sec * 1000 + a->tv_nsec / 1000000;
 }
 
+void timespec_from_nsec(struct timespec *r, int64_t nsec) {
+	r->tv_sec = nsec / NSEC_PER_SEC;
+	r->tv_nsec = nsec % NSEC_PER_SEC;
+}
+
 uint32_t get_current_time_msec(void) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);


### PR DESCRIPTION
*This is the first part of the stuff I played with in the g7-experiments-new branch*

-------------------------------

The hwcomposer backend previously fired a frame event unconditionally at the
refresh rate in milliseconds as obtained by the hwc display configuration.

vsync syncronization happened just before presentation, but an hack was required
to maintain a decent fps rate, de facto emitting frames even when the
display couldn't physically present them.

This commit implements a real rendering loop where a new frame request
is scheduled after every successful buffer swap. The scheduling happens
in a separate file descriptor which gets hooked in the wayland event
loop.

On every vsync event, the timestamp is stored and is used by the scheduling
function to "predict" the next vsync. Scheduled frame events are emitted
at `(next_vsync - idle_time)` or `(next_next_vsync - idle_time)` if the next_vsync
is too close.

`idle_time` is a value that is user tweakable via the `WLR_HWC_IDLE_TIME`
environment variable, and is used to specify a cushion of time that
anticipates the vsync tick. The time is expressed in milliseconds, and
the minimum value is 2, which is also the default.

Slower devices might need an higher idle time value, but keep in mind
that it should be as close as possible to the vsync tick (so don't try
too high values).

vsync gets enabled via a timer started on every display power-on (and
at first start), and disabled on every power-off.

This allowed me to reliably get 60fps on both qx1000 and suzu, with at
least half of the frame events previously emitted.

Scheduling just after the buffer swap also allow us to lower CPU usage -
frames are now scheduled only when there isn't another one pending.

NOTE! This commit breaks hwcomposer 1.x support, since vsync callback
handling is not hooked yet. The good news is that it would be easy to
implement, but I think we could do without hwc1 support for now since
we explicitly target halium-9+.

Also note that this commit needs to be slightly reworked when fixing
multi output support. I've used some shortcuts for simplicity's sake, but
things will not behave well with multiple outputs as things stand now.
