### PR TITLE
backend: hwcomposer: support damage tracking via the EGL_KHR_partial_update extension

### DIFF
--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -57,6 +57,14 @@ struct wlr_output_impl {
 	 */
 	bool (*attach_render)(struct wlr_output *output, int *buffer_age);
 	/**
+	 * HACK: allows to work on the damaged area after the buffer has
+	 * been made current.
+	 *
+	 * This is especially useful when using the EGL_KHR_partial_update
+	 * extension.
+	 */
+	bool (*handle_damage)(struct wlr_output *output, pixman_region32_t *damage);
+	/**
 	 * Unset the current renderer's buffer.
 	 *
 	 * This is the opposite of attach_render.

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -161,6 +161,9 @@ void wlr_egl_save_context(struct wlr_egl_context *context);
  */
 bool wlr_egl_restore_context(struct wlr_egl_context *context);
 
+bool wlr_egl_set_damage_region(struct wlr_egl *egl, EGLSurface surface,
+		pixman_region32_t *damage);
+
 bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 	pixman_region32_t *damage);
 

--- a/include/wlr/render/egl.h
+++ b/include/wlr/render/egl.h
@@ -49,6 +49,7 @@ struct wlr_egl {
 	struct {
 		bool bind_wayland_display_wl;
 		bool buffer_age_ext;
+		bool partial_update_ext;
 		bool image_base_khr;
 		bool image_dma_buf_export_mesa;
 		bool image_dmabuf_import_ext;
@@ -64,6 +65,7 @@ struct wlr_egl {
 		PFNEGLQUERYWAYLANDBUFFERWL eglQueryWaylandBufferWL;
 		PFNEGLBINDWAYLANDDISPLAYWL eglBindWaylandDisplayWL;
 		PFNEGLUNBINDWAYLANDDISPLAYWL eglUnbindWaylandDisplayWL;
+		PFNEGLSETDAMAGEREGIONKHRPROC eglSetDamageRegionKHR;
 		PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC eglSwapBuffersWithDamage; // KHR or EXT
 		PFNEGLQUERYDMABUFFORMATSEXTPROC eglQueryDmaBufFormatsEXT;
 		PFNEGLQUERYDMABUFMODIFIERSEXTPROC eglQueryDmaBufModifiersEXT;

--- a/render/egl.c
+++ b/render/egl.c
@@ -520,6 +520,32 @@ static void transform_damage(EGLDisplay display, EGLSurface surface,
 	}
 }
 
+bool wlr_egl_set_damage_region(struct wlr_egl *egl, EGLSurface surface,
+		pixman_region32_t *damage) {
+	if (!egl->exts.partial_update_ext || damage == NULL) {
+		return true;
+	}
+
+	int nrects;
+	EGLint *egl_damage;
+	EGLBoolean ret;
+
+	transform_damage(egl->display, surface, damage, &nrects,
+		&egl_damage);
+
+	ret = egl->procs.eglSetDamageRegionKHR(egl->display, surface,
+			egl_damage, nrects);
+
+	free(egl_damage);
+
+	if (!ret) {
+		wlr_log(WLR_ERROR, "eglSetDamageRegionKHR failed");
+		return false;
+	}
+
+	return true;
+}
+
 bool wlr_egl_swap_buffers(struct wlr_egl *egl, EGLSurface surface,
 		pixman_region32_t *damage) {
 	// Never block when swapping buffers on Wayland

--- a/render/egl.c
+++ b/render/egl.c
@@ -255,6 +255,12 @@ bool wlr_egl_init(struct wlr_egl *egl, EGLenum platform, void *remote_display,
 	egl->exts.buffer_age_ext =
 		check_egl_ext(display_exts_str, "EGL_EXT_buffer_age");
 
+	if (check_egl_ext(display_exts_str, "EGL_KHR_partial_update")) {
+		egl->exts.partial_update_ext = true;
+		load_egl_proc(&egl->procs.eglSetDamageRegionKHR,
+			"eglSetDamageRegionKHR");
+	}
+
 	if (check_egl_ext(display_exts_str, "EGL_KHR_swap_buffers_with_damage")) {
 		egl->exts.swap_buffers_with_damage = true;
 		load_egl_proc(&egl->procs.eglSwapBuffersWithDamage,
@@ -416,7 +422,7 @@ EGLSurface wlr_egl_create_surface(struct wlr_egl *egl, void *window) {
 }
 
 static int egl_get_buffer_age(struct wlr_egl *egl, EGLSurface surface) {
-	if (!egl->exts.buffer_age_ext) {
+	if (!egl->exts.buffer_age_ext && !egl->exts.partial_update_ext) {
 		return -1;
 	}
 

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -446,6 +446,14 @@ bool wlr_output_attach_render(struct wlr_output *output, int *buffer_age) {
 	return true;
 }
 
+bool wlr_output_handle_damage(struct wlr_output *output, pixman_region32_t *damage) {
+	if (!output->impl->handle_damage) {
+		return false;
+	}
+
+	return output->impl->handle_damage(output, damage);
+}
+
 bool wlr_output_preferred_read_format(struct wlr_output *output,
 		enum wl_shm_format *fmt) {
 	struct wlr_renderer *renderer = wlr_backend_get_renderer(output->backend);

--- a/types/wlr_output_damage.c
+++ b/types/wlr_output_damage.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_output.h>
+#include <wlr/util/log.h>
 #include "util/signal.h"
 
 static void output_handle_destroy(struct wl_listener *listener, void *data) {
@@ -179,6 +180,11 @@ bool wlr_output_damage_attach_render(struct wlr_output_damage *output_damage,
 			pixman_region32_union_rect(damage, damage, extents->x1, extents->y1,
 				extents->x2 - extents->x1, extents->y2 - extents->y1);
 		}
+	}
+
+	// HACK: this should really be done by the compositor rather than us
+	if (!wlr_output_handle_damage(output, damage)) {
+		wlr_log(WLR_ERROR, "Error during handle_damage call");
 	}
 
 	return true;


### PR DESCRIPTION
*This is the second, and final, part of the stuff I played with in the g7-experiments-new branch*

-------------------------------------

Most Android devices don't support the EGL_EXT_buffer_age extension and compositors
should rely on EGL_KHR_partial_update instead.

An explanation of how EGL_KHR_partial_update works can be found on [this
weston issue](https://gitlab.freedesktop.org/wayland/weston/-/issues/134), courtesy of Daniel Stone.

This pull request allows us to query for buffer age should EGL_KHR_partial_update is available, and to set
the damaged region via `eglSetDamageRegionKHR` before attempting to render.

Note that this is implemented in a somewhat hacky way - wlroots API and compositors should be changed in order for this to be implemented in a decent way. Instead, the changes in this pull request make some assumptions on the compositor's behalf to avoid the requirement to patch them.