### PR TITLE
Some hacks to make wake-ups less painful

### DIFF
--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -167,6 +167,16 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 	if (session->active) {
 		libinput_resume(backend->libinput_context);
+
+		// HACK: Forcibly process events if there are any queued
+		// On some devices it has been observed event processing
+		// getting stuck on resume.
+		enum libinput_event_type next_event =
+			libinput_next_event_type(backend->libinput_context);
+		if (next_event != LIBINPUT_EVENT_NONE) {
+			handle_libinput_readable(libinput_get_fd(backend->libinput_context),
+				WL_EVENT_READABLE, backend);
+		}
 	} else {
 		libinput_suspend(backend->libinput_context);
 	}

--- a/include/backend/hwcomposer.h
+++ b/include/backend/hwcomposer.h
@@ -23,6 +23,7 @@ struct wlr_hwcomposer_backend {
 	struct wl_list input_devices;
 	struct wl_listener display_destroy;
 	struct wl_listener session_destroy;
+	struct wl_listener session_signal;
 	bool started;
 	bool is_blank;
 

--- a/include/backend/hwcomposer.h
+++ b/include/backend/hwcomposer.h
@@ -17,10 +17,12 @@ struct wlr_hwcomposer_backend {
 	struct wlr_backend backend;
 	struct wlr_egl egl;
 	struct wlr_renderer *renderer;
+	struct wlr_session *session;
 	struct wl_display *display;
 	struct wl_list outputs;
 	struct wl_list input_devices;
 	struct wl_listener display_destroy;
+	struct wl_listener session_destroy;
 	bool started;
 	bool is_blank;
 

--- a/include/wlr/backend/hwcomposer.h
+++ b/include/wlr/backend/hwcomposer.h
@@ -9,7 +9,7 @@
  * default.
  */
 struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
-	wlr_renderer_create_func_t create_renderer_func);
+	struct wlr_session *session, wlr_renderer_create_func_t create_renderer_func);
 /**
  * Create a new hwcomposer output backed by an in-memory EGL framebuffer. You can
  * read pixels from this framebuffer via wlr_renderer_read_pixels but it is


### PR DESCRIPTION
Some weird behaviours have been observed during wake-up from sleep on some? Droidian devices:

* libinput event processing gets stuck on non-user initiated resumes (i.e. a notification / state change), so unless the user creates an event (for example by touching the screen) queued events won't be processed. The effect of this goes from annoying (unable to answer a call without tapping two times) to straight up no-no (swiping on this awry state makes phosh freeze and then crash afterwards).

* On non-user initiated resumes, phosh's idle timeout does not get armed again, resulting in a display stuck in the enabled state without user interaction.

This pull request workarounds those two issues by:

a) forcibly process libinput events on resume
b) set the expected output state on sleep/resume

For more details, read the individual commits' descriptions. The hwcomposer backend now requires and expects a working session.

Both changes seem to help on qx1000. Tested on both qx1000 and suzu without experiencing weird regressions.

Keeping this as a draft until I have tested this on the wild for a couple of days.