### PR TITLE
HACK: backend: libinput: forcibly process events on resume

### DIFF
--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -167,6 +167,16 @@ static void session_signal(struct wl_listener *listener, void *data) {
 
 	if (session->active) {
 		libinput_resume(backend->libinput_context);
+
+		// HACK: Forcibly process events if there are any queued
+		// On some devices it has been observed event processing
+		// getting stuck on resume.
+		enum libinput_event_type next_event =
+			libinput_next_event_type(backend->libinput_context);
+		if (next_event != LIBINPUT_EVENT_NONE) {
+			handle_libinput_readable(libinput_get_fd(backend->libinput_context),
+				WL_EVENT_READABLE, backend);
+		}
 	} else {
 		libinput_suspend(backend->libinput_context);
 	}


### PR DESCRIPTION
It has been observed that, on wake-up from sleep, event processing
stops completely until an outside event happens (i.e. a touch tap
or a button press).

On Droidian, this caused weird behaviour like inability to interact
with calls on the lock screen on resume (tapping the button a second
time still worked), display waking up again after pressing the power
button to blank it and the shell crashing.

This commit forcibly processes events if there are any queued on
device resume.

This is an hack, and should not be upstreamed.

Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>