### PR TITLE
Refactor, part 1

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -156,11 +156,6 @@ static struct wlr_backend *attempt_hwcomposer_backend(
 		return NULL;
 	}
 
-	size_t outputs = parse_outputs_env("WLR_HWC_OUTPUTS");
-	for (size_t i = 0; i < outputs; ++i) {
-		wlr_hwcomposer_add_output(backend, i, (i == 0));
-	}
-
 	return backend;
 }
 

--- a/backend/backend.c
+++ b/backend/backend.c
@@ -158,7 +158,7 @@ static struct wlr_backend *attempt_hwcomposer_backend(
 
 	size_t outputs = parse_outputs_env("WLR_HWC_OUTPUTS");
 	for (size_t i = 0; i < outputs; ++i) {
-		wlr_hwcomposer_add_output(backend);
+		wlr_hwcomposer_add_output(backend, i, (i == 0));
 	}
 
 	return backend;

--- a/backend/hwcomposer/backend.c
+++ b/backend/hwcomposer/backend.c
@@ -31,6 +31,9 @@ static bool backend_start(struct wlr_backend *wlr_backend) {
 		(struct wlr_hwcomposer_backend *)wlr_backend;
 	wlr_log(WLR_INFO, "Starting hwcomposer backend");
 
+	hwc_backend->started = true;
+
+	// FIXME: Drop this
 	struct wlr_hwcomposer_output *output;
 	wl_list_for_each(output, &hwc_backend->outputs, link) {
 		wl_event_source_timer_update(output->vsync_timer, output->frame_delay);
@@ -39,7 +42,6 @@ static bool backend_start(struct wlr_backend *wlr_backend) {
 			&output->wlr_output);
 	}
 
-	hwc_backend->started = true;
 	return true;
 }
 
@@ -143,9 +145,6 @@ struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
 
 	hwc_backend->hwc_version = hwc_version;
 	hwc_backend->display = display;
-	hwc_backend->is_blank = true; // reset by the set_power_mode call below
-
-	hwc_backend->impl->set_power_mode(hwc_backend, true);
 
 	static EGLint config_attribs[] = {
 		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
@@ -174,6 +173,8 @@ struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
 
 	hwc_backend->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &hwc_backend->display_destroy);
+
+	hwc_backend->egl.display = eglGetDisplay(NULL);
 
 	// Prepare global vsync variables
 	struct timespec now;

--- a/backend/hwcomposer/backend.c
+++ b/backend/hwcomposer/backend.c
@@ -170,6 +170,9 @@ struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
 	hwc_backend->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &hwc_backend->display_destroy);
 
+	// Register hwc callbacks
+	hwc_backend->impl->register_callbacks(hwc_backend);
+
 	return &hwc_backend->backend;
 }
 

--- a/backend/hwcomposer/backend.c
+++ b/backend/hwcomposer/backend.c
@@ -4,7 +4,22 @@
 #include <wlr/render/egl.h>
 #include <wlr/render/gles2.h>
 #include <wlr/util/log.h>
+#include <assert.h>
 #include "backend/hwcomposer.h"
+
+inline static uint32_t interpreted_version(hw_device_t *hwc_device)
+{
+	uint32_t version = hwc_device->version;
+
+	if ((version & 0xffff0000) == 0) {
+		// Assume header version is always 1
+		uint32_t header_version = 1;
+
+		// Legacy version encoding
+		version = (version << 16) | header_version;
+	}
+	return version;
+}
 
 static bool backend_start(struct wlr_backend *wlr_backend) {
 	struct wlr_hwcomposer_backend *backend =
@@ -63,21 +78,69 @@ static void handle_display_destroy(struct wl_listener *listener, void *data) {
 	backend_destroy(&backend->backend);
 }
 
+void hwcomposer_init(struct wlr_hwcomposer_backend *hwc_backend) {
+	wlr_log(WLR_INFO, "Creating hwcomposer backend");
+	wlr_backend_init(&hwc_backend->backend, &backend_impl);
+	wl_list_init(&hwc_backend->outputs);
+
+	// Get idle time from the environment, if specified
+	char *idle_time_env = getenv("WLR_HWC_IDLE_TIME");
+	if (idle_time_env) {
+		char *end;
+		int idle_time = (int)strtol(idle_time_env, &end, 10);
+
+		hwc_backend->idle_time = (*end || idle_time < 2) ? 2 * 1000000 : idle_time * 1000000;
+	} else {
+		// Default to 2
+		hwc_backend->idle_time = 2 * 1000000;
+	}
+}
+
 struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
 		wlr_renderer_create_func_t create_renderer_func) {
-	wlr_log(WLR_INFO, "Creating hwcomposer backend");
+	int err;
+	struct wlr_hwcomposer_backend *backend;
+	hw_module_t *hwc_module = 0;
+	hw_device_t *hwc_device = NULL;
+#ifdef HWC_DEVICE_API_VERSION_2_0
+	int hwc_version = HWC_DEVICE_API_VERSION_2_0;
+#else
+	int hwc_version = HWC_DEVICE_API_VERSION_1_3;
+#endif // HWC_DEVICE_API_VERSION_2_0
 
-	struct wlr_hwcomposer_backend *backend =
-		calloc(1, sizeof(struct wlr_hwcomposer_backend));
-	if (!backend) {
-		wlr_log(WLR_ERROR, "Failed to allocate wlr_hwcomposer_backend");
-		return NULL;
+	err = hw_get_module(HWC_HARDWARE_MODULE_ID, (const hw_module_t **) &hwc_module);
+	assert(err == 0);
+
+	wlr_log(WLR_INFO, "== hwcomposer module ==\n");
+	wlr_log(WLR_INFO, " * Address: %p\n", hwc_module);
+	wlr_log(WLR_INFO, " * Module API Version: %x\n", hwc_module->module_api_version);
+	wlr_log(WLR_INFO, " * HAL API Version: %x\n", hwc_module->hal_api_version); /* should be zero */
+	wlr_log(WLR_INFO, " * Identifier: %s\n", hwc_module->id);
+	wlr_log(WLR_INFO, " * Name: %s\n", hwc_module->name);
+	wlr_log(WLR_INFO, " * Author: %s\n", hwc_module->author);
+	wlr_log(WLR_INFO, "== hwcomposer module ==\n");
+
+	err = hwc_module->methods->open(hwc_module, HWC_HARDWARE_COMPOSER, &hwc_device);
+	if (!err) {
+		// If there is an error, use the default (hwc2). It seems that on some
+		// hwc2 devices the open call fails.
+		hwc_version = interpreted_version(hwc_device);
 	}
-	wlr_backend_init(&backend->backend, &backend_impl);
-	backend->display = display;
-	wl_list_init(&backend->outputs);
 
-	hwcomposer_api_init(backend);
+#ifdef HWC_DEVICE_API_VERSION_2_0
+	if (hwc_version == HWC_DEVICE_API_VERSION_2_0)
+		backend = hwcomposer2_api_init(hwc_device);
+	else
+#endif // HWC_DEVICE_API_VERSION_2_0
+		backend = hwcomposer_api_init(hwc_device);
+
+	wlr_log(WLR_INFO, "HWC Version=%x\n", hwc_version);
+
+	backend->hwc_version = hwc_version;
+	backend->display = display;
+	backend->is_blank = true; // reset by the set_power_mode call below
+
+	backend->impl->set_power_mode(backend, true);
 
 	static EGLint config_attribs[] = {
 		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,

--- a/backend/hwcomposer/backend.c
+++ b/backend/hwcomposer/backend.c
@@ -1,3 +1,7 @@
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "util/signal.h"
 #include <stdlib.h>
 #include <wlr/interfaces/wlr_output.h>
@@ -5,6 +9,7 @@
 #include <wlr/render/gles2.h>
 #include <wlr/util/log.h>
 #include <assert.h>
+#include "time.h"
 #include "backend/hwcomposer.h"
 
 inline static uint32_t interpreted_version(hw_device_t *hwc_device)
@@ -169,6 +174,12 @@ struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
 
 	hwc_backend->display_destroy.notify = handle_display_destroy;
 	wl_display_add_destroy_listener(display, &hwc_backend->display_destroy);
+
+	// Prepare global vsync variables
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	hwc_backend->hwc_vsync_last_timestamp = now.tv_sec * 1000000000 + now.tv_nsec;
+	hwc_backend->hwc_vsync_enabled = false;
 
 	// Register hwc callbacks
 	hwc_backend->impl->register_callbacks(hwc_backend);

--- a/backend/hwcomposer/hwcomposer.c
+++ b/backend/hwcomposer/hwcomposer.c
@@ -183,7 +183,14 @@ struct wlr_hwcomposer_backend *hwcomposer_api_init(hw_device_t *hwc_device)
 	return &hwc1->hwc_backend;
 }
 
+static void hwcomposer_register_callbacks(struct wlr_hwcomposer_backend *hwc_backend)
+{
+	// TODO: implement this
+}
+
+
 const struct hwcomposer_impl hwcomposer_hwc1 = {
+	.register_callbacks = hwcomposer_register_callbacks,
 	.present = hwcomposer_present,
 	.vsync_control = hwcomposer_vsync_control,
 	.set_power_mode = hwcomposer_set_power_mode,

--- a/backend/hwcomposer/hwcomposer2.c
+++ b/backend/hwcomposer/hwcomposer2.c
@@ -10,7 +10,10 @@
 
 #include <hybris/hwcomposerwindow/hwcomposer.h>
 
+#include <hybris/hwc2/hwc2_compatibility_layer.h>
+
 #include <wlr/util/log.h>
+#include <wlr/interfaces/wlr_output.h>
 
 #include "backend/hwcomposer.h"
 
@@ -27,9 +30,16 @@ struct wlr_hwcomposer_backend_hwc2
 {
 	struct wlr_hwcomposer_backend hwc_backend;
 
-	hwc2_compat_device_t* hwc2_device;
-	hwc2_compat_display_t* hwc2_primary_display;
-	hwc2_compat_layer_t* hwc2_primary_layer;
+	hwc2_compat_device_t *hwc2_device;
+};
+
+struct wlr_hwcomposer_output_hwc2
+{
+	struct wlr_hwcomposer_output output;
+
+	hwc2_compat_display_t *hwc2_display;
+	hwc2_compat_layer_t *hwc2_layer;
+	int hwc2_last_present_fence;
 };
 
 static struct wlr_hwcomposer_backend_hwc2 *hwc2_backend_from_base(struct wlr_hwcomposer_backend *hwc_backend)
@@ -38,12 +48,17 @@ static struct wlr_hwcomposer_backend_hwc2 *hwc2_backend_from_base(struct wlr_hwc
 	return (struct wlr_hwcomposer_backend_hwc2 *)hwc_backend;
 }
 
+static struct wlr_hwcomposer_output_hwc2 *hwc2_output_from_base(struct wlr_hwcomposer_output *output)
+{
+	// TODO: ensure it's the correct one?
+	return (struct wlr_hwcomposer_output_hwc2 *)output;
+}
+
 static void hwcomposer2_vsync_callback(HWC2EventListener* listener, int32_t sequence_id,
 		hwc2_display_t display, int64_t timestamp)
 {
 	struct wlr_hwcomposer_backend_hwc2 *hwc2 = ((hwc_procs_v20 *)listener)->hwc2;
 
-	// FIXME: This will cause issues with multiple displays
 	hwc2->hwc_backend.hwc_vsync_last_timestamp = timestamp;
 }
 
@@ -68,9 +83,6 @@ static void hwcomposer2_refresh_callback(HWC2EventListener* listener, int32_t se
 
 struct wlr_hwcomposer_backend* hwcomposer2_api_init(hw_device_t *hwc_device)
 {
-	int err;
-	static int composer_sequence_id = 0;
-	struct wlr_hwcomposer_backend *hwc_backend;
 	struct wlr_hwcomposer_backend_hwc2 *hwc2 =
 		calloc(1, sizeof(struct wlr_hwcomposer_backend_hwc2));
 	if (!hwc2) {
@@ -79,92 +91,70 @@ struct wlr_hwcomposer_backend* hwcomposer2_api_init(hw_device_t *hwc_device)
 	}
 
 	hwcomposer_init (&hwc2->hwc_backend);
-	hwc_backend = &hwc2->hwc_backend;
-
-	hwc_procs_v20* procs = malloc(sizeof(hwc_procs_v20));
-	procs->listener.on_vsync_received = hwcomposer2_vsync_callback;
-	procs->listener.on_hotplug_received = hwcomposer2_hotplug_callback;
-	procs->listener.on_refresh_received = hwcomposer2_refresh_callback;
-	procs->hwc2 = hwc2;
 
 	hwc2_compat_device_t* hwc2_device = hwc2->hwc2_device = hwc2_compat_device_new(false);
 	assert(hwc2_device);
-
-	//hwc_set_power_mode(pScrn, HWC_DISPLAY_PRIMARY, 1);
-
-	hwc2_compat_device_register_callback(hwc2_device, &procs->listener,
-		composer_sequence_id++);
-
-	for (int i = 0; i < 5 * 1000; ++i) {
-		// Wait at most 5s for hotplug events
-		if ((hwc2->hwc2_primary_display =
-			hwc2_compat_device_get_display_by_id(hwc2_device, 0)))
-			break;
-		sleep(1000);
-	}
-	assert(hwc2->hwc2_primary_display);
-
-	HWC2DisplayConfig *config = hwc2_compat_display_get_active_config(hwc2->hwc2_primary_display);
-	assert(config);
-
-	hwc_backend->hwc_width = config->width;
-	hwc_backend->hwc_height = config->height;
-	hwc_backend->hwc_refresh = config->vsyncPeriod;
-	hwc_backend->hwc_refresh = (config->vsyncPeriod == 0) ?
-		(1000000000000LL / HWCOMPOSER_DEFAULT_REFRESH) : config->vsyncPeriod;
-	wlr_log(WLR_INFO, "width: %i height: %i Refresh: %i\n", config->width, config->height, hwc_backend->hwc_refresh);
-
-	hwc2_compat_layer_t* layer = hwc2->hwc2_primary_layer =
-		hwc2_compat_display_create_layer(hwc2->hwc2_primary_display);
-
-	hwc2_compat_layer_set_composition_type(layer, HWC2_COMPOSITION_CLIENT);
-	hwc2_compat_layer_set_blend_mode(layer, HWC2_BLEND_MODE_NONE);
-	hwc2_compat_layer_set_source_crop(layer, 0.0f, 0.0f, hwc_backend->hwc_width, hwc_backend->hwc_height);
-	hwc2_compat_layer_set_display_frame(layer, 0, 0, hwc_backend->hwc_width, hwc_backend->hwc_height);
-	hwc2_compat_layer_set_visible_region(layer, 0, 0, hwc_backend->hwc_width, hwc_backend->hwc_height);
 
 	hwc2->hwc_backend.impl = &hwcomposer_hwc2;
 
 	return &hwc2->hwc_backend;
 }
-
 static void hwcomposer2_close(struct wlr_hwcomposer_backend *hwc_backend)
 {
 }
 
-static void hwcomposer2_vsync_control(struct wlr_hwcomposer_backend *hwc_backend, bool enable)
+static bool hwcomposer2_vsync_control(struct wlr_hwcomposer_output *output, bool enable)
 {
-	struct wlr_hwcomposer_backend_hwc2 *hwc2 = hwc2_backend_from_base(hwc_backend);
+	struct wlr_hwcomposer_backend *hwc_backend = output->hwc_backend;
+	struct wlr_hwcomposer_output_hwc2 *hwc2_output = hwc2_output_from_base(output);
 
-	if (hwc_backend->hwc_vsync_enabled == enable) {
-		return;
+	wlr_log(WLR_DEBUG, "hwcomposer2: vsync_control: display %p, enable %d",
+		hwc2_output->hwc2_display, enable);
+
+	if (!output->hwc_is_primary || hwc_backend->hwc_vsync_enabled == enable) {
+		return true;
 	}
 
-	hwc2_compat_display_set_vsync_enabled(hwc2->hwc2_primary_display, enable ? HWC2_VSYNC_ENABLE : HWC2_VSYNC_DISABLE);
-	hwc_backend->hwc_vsync_enabled = enable;
+	if (hwc2_compat_display_set_vsync_enabled(hwc2_output->hwc2_display, enable ?
+		HWC2_VSYNC_ENABLE : HWC2_VSYNC_DISABLE) == HWC2_ERROR_NONE) {
+		hwc_backend->hwc_vsync_enabled = enable;
+
+		return true;
+	}
+
+	return false;
 }
 
-static void hwcomposer2_set_power_mode(struct wlr_hwcomposer_backend *hwc_backend, bool enable)
+static bool hwcomposer2_set_power_mode(struct wlr_hwcomposer_output *output, bool enable)
 {
-	struct wlr_hwcomposer_backend_hwc2 *hwc2 = hwc2_backend_from_base(hwc_backend);
+	struct wlr_hwcomposer_output_hwc2 *hwc2_output = hwc2_output_from_base(output);
 
-	hwc_backend->is_blank = !hwc_backend->is_blank;
-	hwcomposer2_vsync_control(hwc_backend, hwc_backend->is_blank);
+	wlr_log(WLR_DEBUG, "hwcomposer2: set_power_mode: display %p, enable %d",
+		hwc2_output->hwc2_display, enable);
 
-	hwc2_compat_display_set_power_mode(hwc2->hwc2_primary_display, hwc_backend->is_blank ? HWC2_POWER_MODE_OFF : HWC2_POWER_MODE_ON);
+	if (!enable && !hwcomposer2_vsync_control(output, enable)) {
+		wlr_log(WLR_ERROR, "hwcomposer2: set_power_mode: unable to disable vsync");
+	}
+
+	if (hwc2_compat_display_set_power_mode(hwc2_output->hwc2_display, enable ?
+		HWC2_POWER_MODE_ON : HWC2_POWER_MODE_OFF) == HWC2_ERROR_NONE) {
+		wlr_output_update_enabled(&output->wlr_output, enable);
+
+		return true;
+	}
+
+	return false;
 }
 
 static void hwcomposer2_present(void *user_data, struct ANativeWindow *window,
 		struct ANativeWindowBuffer *buffer)
 {
-	struct wlr_hwcomposer_backend *hwc_backend = (struct wlr_hwcomposer_backend *)user_data;
-	struct wlr_hwcomposer_backend_hwc2 *hwc2 = hwc2_backend_from_base(hwc_backend);
-
-	static int last_present_fence = -1;
+	struct wlr_hwcomposer_output *output = (struct wlr_hwcomposer_output *)user_data;
+	struct wlr_hwcomposer_output_hwc2 *hwc2_output = hwc2_output_from_base(output);
+	struct wlr_hwcomposer_backend *hwc_backend = output->hwc_backend;
 
 	uint32_t num_types = 0;
 	uint32_t num_requests = 0;
-	int display_id = 0;
 	hwc2_error_t error = HWC2_ERROR_NONE;
 
 	int acquireFenceFd = HWCNativeBufferGetFence(buffer);
@@ -176,18 +166,19 @@ static void hwcomposer2_present(void *user_data, struct ANativeWindow *window,
 		acquireFenceFd = -1;
 	}
 
-	hwc2_compat_display_t* hwc_display = hwc2->hwc2_primary_display;
+	hwc2_compat_display_t* hwc_display = hwc2_output->hwc2_display;
 
 	error = hwc2_compat_display_validate(hwc_display, &num_types,
 		&num_requests);
 	if (error != HWC2_ERROR_NONE && error != HWC2_ERROR_HAS_CHANGES) {
-		wlr_log(WLR_ERROR, "prepare: validate failed for display %d: %d", display_id, error);
+		wlr_log(WLR_ERROR, "prepare: validate failed for display %lld: %d",
+			output->hwc_display_id, error);
 		return;
 	}
 
 	if (num_types || num_requests) {
-		wlr_log(WLR_ERROR, "prepare: validate required changes for display %d: %d",
-			display_id, error);
+		wlr_log(WLR_ERROR, "prepare: validate required changes for display %lld: %d",
+			output->hwc_display_id, error);
 		return;
 	}
 
@@ -201,18 +192,68 @@ static void hwcomposer2_present(void *user_data, struct ANativeWindow *window,
 		acquireFenceFd,
 		HAL_DATASPACE_UNKNOWN);
 
-	hwcomposer2_vsync_control(hwc_backend, true);
 	int present_fence = -1;
 	hwc2_compat_display_present(hwc_display, &present_fence);
 
-	if (last_present_fence != -1) {
-		sync_wait(last_present_fence, -1);
-		close(last_present_fence);
+	if (hwc2_output->hwc2_last_present_fence != -1) {
+		sync_wait(hwc2_output->hwc2_last_present_fence, -1);
+		close(hwc2_output->hwc2_last_present_fence);
 	}
 
-	last_present_fence = present_fence != -1 ? dup(present_fence) : -1;
+	hwc2_output->hwc2_last_present_fence = present_fence != -1 ? dup(present_fence) : -1;
 
 	HWCNativeBufferSetFence(buffer, present_fence);
+}
+
+static struct wlr_hwcomposer_output* hwcomposer2_add_output(struct wlr_hwcomposer_backend *hwc_backend, int display)
+{
+	struct wlr_hwcomposer_backend_hwc2 *hwc2 = hwc2_backend_from_base(hwc_backend);
+	struct wlr_hwcomposer_output_hwc2 *hwc2_output =
+		calloc(1, sizeof(struct wlr_hwcomposer_output_hwc2));
+	if (hwc2_output == NULL) {
+		wlr_log(WLR_ERROR, "Failed to allocate wlr_hwcomposer_output_hwc2");
+		return NULL;
+	}
+
+	hwc2_output->hwc2_display = hwc2_compat_device_get_display_by_id(hwc2->hwc2_device, display);
+	hwc2_output->output.hwc_is_primary = (display == 0);
+
+	HWC2DisplayConfig *config = hwc2_compat_display_get_active_config(hwc2_output->hwc2_display);
+	assert(config);
+
+	hwc2_output->output.hwc_width = config->width;
+	hwc2_output->output.hwc_height = config->height;
+	hwc2_output->output.hwc_refresh = (config->vsyncPeriod == 0) ?
+		(1000000000000LL / HWCOMPOSER_DEFAULT_REFRESH) : config->vsyncPeriod;
+	wlr_log(WLR_INFO, "width: %i height: %i Refresh: %i\n", config->width, config->height, hwc2_output->output.hwc_refresh);
+
+	hwc2_compat_layer_t* layer = hwc2_output->hwc2_layer =
+		hwc2_compat_display_create_layer(hwc2_output->hwc2_display);
+
+	hwc2_compat_layer_set_composition_type(layer, HWC2_COMPOSITION_CLIENT);
+	hwc2_compat_layer_set_blend_mode(layer, HWC2_BLEND_MODE_NONE);
+	hwc2_compat_layer_set_source_crop(layer, 0.0f, 0.0f, hwc2_output->output.hwc_width, hwc2_output->output.hwc_height);
+	hwc2_compat_layer_set_display_frame(layer, 0, 0, hwc2_output->output.hwc_width, hwc2_output->output.hwc_height);
+	hwc2_compat_layer_set_visible_region(layer, 0, 0, hwc2_output->output.hwc_width, hwc2_output->output.hwc_height);
+
+	hwc2_output->hwc2_last_present_fence = -1;
+
+	// FIXME: This being here is wrong
+	if (hwc2_output->output.hwc_is_primary) {
+		hwc2->hwc_backend.hwc_device_refresh = hwc2_output->output.hwc_refresh;
+	}
+
+	return &hwc2_output->output;
+}
+
+static void hwcomposer2_destroy_output(struct wlr_hwcomposer_output *output)
+{
+	struct wlr_hwcomposer_output_hwc2 *hwc2_output = hwc2_output_from_base(output);
+	struct wlr_hwcomposer_backend_hwc2 *hwc2 = hwc2_backend_from_base(output->hwc_backend);
+
+	hwc2_compat_device_destroy_display(hwc2->hwc2_device, hwc2_output->hwc2_display);
+
+	free(hwc2_output);
 }
 
 static void hwcomposer2_register_callbacks(struct wlr_hwcomposer_backend *hwc_backend)
@@ -237,6 +278,8 @@ const struct hwcomposer_impl hwcomposer_hwc2 = {
 	.present = hwcomposer2_present,
 	.vsync_control = hwcomposer2_vsync_control,
 	.set_power_mode = hwcomposer2_set_power_mode,
+	.add_output = hwcomposer2_add_output,
+	.destroy_output = hwcomposer2_destroy_output,
 	.close = hwcomposer2_close,
 };
 #endif // HWC_DEVICE_API_VERSION_2_0

--- a/backend/hwcomposer/hwcomposer2.c
+++ b/backend/hwcomposer/hwcomposer2.c
@@ -215,7 +215,25 @@ static void hwcomposer2_present(void *user_data, struct ANativeWindow *window,
 	HWCNativeBufferSetFence(buffer, present_fence);
 }
 
+static void hwcomposer2_register_callbacks(struct wlr_hwcomposer_backend *hwc_backend)
+{
+	int composer_sequence_id = 0;
+	struct wlr_hwcomposer_backend_hwc2 *hwc2 = hwc2_backend_from_base(hwc_backend);
+
+	hwc_procs_v20* procs = malloc(sizeof(hwc_procs_v20));
+	procs->listener.on_vsync_received = hwcomposer2_vsync_callback;
+	procs->listener.on_hotplug_received = hwcomposer2_hotplug_callback;
+	procs->listener.on_refresh_received = hwcomposer2_refresh_callback;
+	procs->hwc2 = hwc2;
+
+	hwc2_compat_device_register_callback(hwc2->hwc2_device, &procs->listener,
+		composer_sequence_id++);
+
+	wlr_log(WLR_DEBUG, "hwcomposer2: register_callbaks: callbacks registered");
+}
+
 const struct hwcomposer_impl hwcomposer_hwc2 = {
+	.register_callbacks = hwcomposer2_register_callbacks,
 	.present = hwcomposer2_present,
 	.vsync_control = hwcomposer2_vsync_control,
 	.set_power_mode = hwcomposer2_set_power_mode,

--- a/backend/hwcomposer/hwcomposer2.c
+++ b/backend/hwcomposer/hwcomposer2.c
@@ -74,6 +74,9 @@ static void hwcomposer2_hotplug_callback(HWC2EventListener* listener, int32_t se
 		primary_display ? "primary\n" : "external\n");
 
 	hwc2_compat_device_on_hotplug(hwc2->hwc2_device, display, connected);
+
+	wlr_hwcomposer_backend_handle_hotplug((struct wlr_backend *)hwc2,
+		(uint64_t)display, connected, primary_display);
 }
 
 static void hwcomposer2_refresh_callback(HWC2EventListener* listener, int32_t sequence_id,

--- a/backend/hwcomposer/output.c
+++ b/backend/hwcomposer/output.c
@@ -349,11 +349,6 @@ struct wlr_output *wlr_hwcomposer_add_output(struct wlr_backend *wlr_backend) {
 
 	wl_list_insert(&hwc_backend->outputs, &output->link);
 
-	// FIXME: This will break on multiple outputs!
-	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
-	hwc_backend->hwc_vsync_last_timestamp = now.tv_sec * 1000000000 + now.tv_nsec;
-
 	output->vsync_timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC | TFD_NONBLOCK);
 	if (output->vsync_timer_fd < 0) {
 		wlr_log(WLR_ERROR, "Failed to create vsync timer fd");

--- a/debian/drone.star
+++ b/debian/drone.star
@@ -15,7 +15,9 @@ BUILD_ON = [
 # Extra Debian repositories to add. These can be used to pull packages
 # from other feature branches.
 # Note that builds with EXTRA_REPOS won't start on production or staging.
-EXTRA_REPOS = []
+EXTRA_REPOS = [
+	"deb http://droidian-libhybris.repo.droidian.org/bullseye-multiwindow/ bullseye main",
+]
 
 # Host architecture. This can be used to instruct the buildd to
 # assume the packages are built (host -> should be executed on) for the

--- a/include/backend/hwcomposer.h
+++ b/include/backend/hwcomposer.h
@@ -48,7 +48,7 @@ struct wlr_hwcomposer_backend {
 struct wlr_hwcomposer_output {
 	struct wlr_output wlr_output;
 
-	struct wlr_hwcomposer_backend *backend;
+	struct wlr_hwcomposer_backend *hwc_backend;
 	struct wl_list link;
 
 	struct ANativeWindow *egl_window;

--- a/include/backend/hwcomposer.h
+++ b/include/backend/hwcomposer.h
@@ -62,6 +62,7 @@ struct wlr_hwcomposer_output {
 };
 
 struct hwcomposer_impl {
+	void (*register_callbacks)(struct wlr_hwcomposer_backend *hwc_backend);
 	void (*present)(void *user_data, struct ANativeWindow *window, struct ANativeWindowBuffer *buffer);
 	void (*vsync_control)(struct wlr_hwcomposer_backend *hwc_backend, bool enable);
 	void (*set_power_mode)(struct wlr_hwcomposer_backend *hwc_backend, bool enable);

--- a/include/backend/hwcomposer.h
+++ b/include/backend/hwcomposer.h
@@ -67,6 +67,8 @@ struct wlr_hwcomposer_output {
 	int frame_delay; // ms
 	int vsync_timer_fd;
 	struct wl_event_source *vsync_event;
+
+	bool should_destroy;
 };
 
 struct hwcomposer_impl {

--- a/include/backend/hwcomposer.h
+++ b/include/backend/hwcomposer.h
@@ -26,21 +26,19 @@ struct wlr_hwcomposer_backend {
 	struct wl_list input_devices;
 	struct wl_listener display_destroy;
 	bool started;
-	bool is_blank;
 
 	uint32_t hwc_version;
-	int hwc_width;
-	int hwc_height;
-	int64_t hwc_refresh;
 	bool hwc_vsync_enabled;
 
 	int64_t idle_time; // nsec
 
+	// This is the refresh rate of the main display. Every display is driven
+	// by the VSYNC signal of the primary one, so this is going to be the
+	// maximum refresh rate supported.
+	int64_t hwc_device_refresh;
+
 	// Per the Android docs, every display is driven by the VSYNC signal
 	// of the internal one, so it makes sense to keep this into the backend.
-	bool vsync_frame_pending;
-	int vsync_timer_fd;
-	struct wl_event_source *vsync_event;
 	int64_t hwc_vsync_last_timestamp;
 	// TODO: Also store 'vsyncPeriodNanos' if vsync2_4 is supported
 };
@@ -55,22 +53,33 @@ struct wlr_hwcomposer_output {
 	void *egl_display;
 	void *egl_surface;
 
-	bool needs_frame;
+	struct wlr_egl egl;
+
+	bool hwc_is_primary;
+	uint64_t hwc_display_id;
+	int hwc_left;
+	int hwc_top;
+	int hwc_width;
+	int hwc_height;
+	int64_t hwc_refresh;
 
 	struct wl_event_source *vsync_timer;
 	int frame_delay; // ms
+	int vsync_timer_fd;
+	struct wl_event_source *vsync_event;
 };
 
 struct hwcomposer_impl {
 	void (*register_callbacks)(struct wlr_hwcomposer_backend *hwc_backend);
 	void (*present)(void *user_data, struct ANativeWindow *window, struct ANativeWindowBuffer *buffer);
-	void (*vsync_control)(struct wlr_hwcomposer_backend *hwc_backend, bool enable);
-	void (*set_power_mode)(struct wlr_hwcomposer_backend *hwc_backend, bool enable);
+	bool (*vsync_control)(struct wlr_hwcomposer_output *output, bool enable);
+	bool (*set_power_mode)(struct wlr_hwcomposer_output *output, bool enable);
+	struct wlr_hwcomposer_output *(*add_output)(struct wlr_hwcomposer_backend *hwc_backend, int display);
+	void (*destroy_output)(struct wlr_hwcomposer_output *output);
 	void (*close)(struct wlr_hwcomposer_backend *hwc_backend);
 };
 
 void hwcomposer_init(struct wlr_hwcomposer_backend *hwc_backend);
-void hwcomposer_schedule_frame(struct wlr_hwcomposer_backend *hwc_backend);
 struct wlr_hwcomposer_backend *hwcomposer_api_init(hw_device_t *hwc_device);
 #ifdef HWC_DEVICE_API_VERSION_2_0
 struct wlr_hwcomposer_backend *hwcomposer2_api_init(hw_device_t *hwc_device);

--- a/include/wlr/backend/hwcomposer.h
+++ b/include/wlr/backend/hwcomposer.h
@@ -17,6 +17,11 @@ struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
  */
 struct wlr_output *wlr_hwcomposer_add_output(struct wlr_backend *wlr_backend,
 	uint64_t display, bool primary_display);
+/**
+ * Schedule the destroy of an hwcomposer output. You can use this to safely
+ * destroy a connected output.
+ */
+void wlr_hwcomposer_output_schedule_destroy(struct wlr_output *wlr_output);
 
 bool wlr_backend_is_hwcomposer(struct wlr_backend *backend);
 bool wlr_output_is_hwcomposer(struct wlr_output *output);

--- a/include/wlr/backend/hwcomposer.h
+++ b/include/wlr/backend/hwcomposer.h
@@ -15,7 +15,8 @@ struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
  * read pixels from this framebuffer via wlr_renderer_read_pixels but it is
  * otherwise not displayed.
  */
-struct wlr_output *wlr_hwcomposer_add_output(struct wlr_backend *backend);
+struct wlr_output *wlr_hwcomposer_add_output(struct wlr_backend *wlr_backend,
+	uint64_t display, bool primary_display);
 
 bool wlr_backend_is_hwcomposer(struct wlr_backend *backend);
 bool wlr_output_is_hwcomposer(struct wlr_output *output);

--- a/include/wlr/backend/hwcomposer.h
+++ b/include/wlr/backend/hwcomposer.h
@@ -22,6 +22,11 @@ struct wlr_output *wlr_hwcomposer_add_output(struct wlr_backend *wlr_backend,
  * destroy a connected output.
  */
 void wlr_hwcomposer_output_schedule_destroy(struct wlr_output *wlr_output);
+/**
+ * Handle hwcomposer hotplug events.
+*/
+void wlr_hwcomposer_backend_handle_hotplug(struct wlr_backend *wlr_backend,
+	uint64_t display, bool connected, bool primary_display);
 
 bool wlr_backend_is_hwcomposer(struct wlr_backend *backend);
 bool wlr_output_is_hwcomposer(struct wlr_output *output);


### PR DESCRIPTION
Let's do this incrementally so that I could also work on other things :smile: 

This pull request refactors the hwcomposer backend a bit. Most relevant changes are:

* The two hwc implementations now implement a generic interface. They don't depend on each other anymore
* The backend doesn't assume a single output anymore. Control functions (vsync, set_power_mode, etc) now work per-output
* Control functions now return a boolean with the relevant result
* Outputs can now be added and destroyed at will
* The backend now reacts on HWC2 hotplug events

More details in the various commits' descriptions.

TL;DR: If your device supports it, HDMI output/convergence works! :tada: :partying_face: 