### PR TITLE
Various fixes taken from the refactor branch

### DIFF
--- a/backend/hwcomposer/output.c
+++ b/backend/hwcomposer/output.c
@@ -111,7 +111,7 @@ static bool output_set_custom_mode(struct wlr_output *wlr_output, int32_t width,
 		return false;
 	}
 
-	output->frame_delay = refresh * 0.000001;
+	output->frame_delay = 1000000 / refresh;
 
 	wlr_output_update_custom_mode(&output->wlr_output, width, height, refresh);
 	return true;
@@ -348,7 +348,10 @@ struct wlr_output *wlr_hwcomposer_add_output(struct wlr_backend *wlr_backend) {
 	backend->egl.display = output->egl_display;
 
 	output_set_custom_mode(wlr_output, backend->hwc_width,
-		backend->hwc_height, backend->hwc_refresh);
+		backend->hwc_height,
+		backend->hwc_refresh ?
+			(1000000000000LL / backend->hwc_refresh) :
+			0);
 	strncpy(wlr_output->make, "hwcomposer", sizeof(wlr_output->make));
 	strncpy(wlr_output->model, "hwcomposer", sizeof(wlr_output->model));
 	snprintf(wlr_output->name, sizeof(wlr_output->name), "HWCOMPOSER-%d",

--- a/render/gles2/shaders.c
+++ b/render/gles2/shaders.c
@@ -80,9 +80,9 @@ const GLchar tex_fragment_src_external[] =
 "#extension GL_OES_EGL_image_external : require\n\n"
 "precision mediump float;\n"
 "varying vec2 v_texcoord;\n"
-"uniform samplerExternalOES texture0;\n"
+"uniform samplerExternalOES tex;\n"
 "uniform float alpha;\n"
 "\n"
 "void main() {\n"
-"	gl_FragColor = texture2D(texture0, v_texcoord) * alpha;\n"
+"	gl_FragColor = texture2D(tex, v_texcoord) * alpha;\n"
 "}\n";


### PR DESCRIPTION
This PR cherry-picks some trivial fixes taken from #6:

* **backend: hwcomposer: ensure we report the correct refresh rate** 
We were previously (perhaps after #1 ? Don't remember it happening before but could be wrong) reporting a terribly wrong refresh rate. This fixes that.

* **gles2: rename texture0 to tex in fragment_src_external**
(I should submit this to upstream as well) https://github.com/droidian/wlroots/blob/feature/bullseye/various-fixes/render/gles2/renderer.c#L777 is looking for `tex`, but the uniform was actually called `texture0`. This commit simply renames it to `tex` for consistency. A symptom of this bug would be the compositor spamming 

```
[GLES2] location of the uniform is -1
```

* **HACK: backend: hwcomposer: do not adjust sequence id when sending a presentation event**
This is a curious one. There probably is some other underlying bug in our backend, but as things stand now software using the `wp_presentation` protocol would rapidly slow down the whole compositor (!). The most offending effect would be a rapid decrease in FPS that can only be recovered by restarting the compositor.  
For backends that do not offer precise presentation feedback events (like ours for now, but it can be implemented later), wlroots will take care to send a non-precise event using the current time. Since presentation events are meant to be sent *after* the commit has been applied, wlroots helpfully reports an event for `commit_seq + 1`.
For some non-obvious reason (to me, at least) we aren't actually off-by-one, and we were always sending a frame event not matching the surface's. The event won't actually make it to the client due to this discrepancy, leaving an always-increasing amount of feedback requests open.
WayDroid and `weston-presentation-shm` seem to work correctly with this fix.