### PR TITLE
hwcomposer2: set brightness when toggling screen

### DIFF
--- a/backend/hwcomposer/backend.c
+++ b/backend/hwcomposer/backend.c
@@ -229,6 +229,12 @@ struct wlr_backend *wlr_hwcomposer_backend_create(struct wl_display *display,
 	hwc_backend->hwc_vsync_last_timestamp = now.tv_sec * 1000000000 + now.tv_nsec;
 	hwc_backend->hwc_vsync_enabled = false;
 
+	// Create a udev instance for panel brightness control
+	if (getenv("WLR_HWC_SYSFS_BACKLIGHT") != NULL)
+		hwc_backend->udev = udev_new();
+	else
+		hwc_backend->udev = NULL;
+
 	// Register hwc callbacks
 	hwc_backend->impl->register_callbacks(hwc_backend);
 

--- a/include/backend/hwcomposer.h
+++ b/include/backend/hwcomposer.h
@@ -41,6 +41,9 @@ struct wlr_hwcomposer_backend {
 	// of the internal one, so it makes sense to keep this into the backend.
 	int64_t hwc_vsync_last_timestamp;
 	// TODO: Also store 'vsyncPeriodNanos' if vsync2_4 is supported
+
+	// A udev instance for panel brightness control
+	struct udev *udev;
 };
 
 struct wlr_hwcomposer_output {


### PR DESCRIPTION
Some MTKs leave the panel on when turning off the screen. This means we need to manually set the brighness to zero on when turning off the screen and restore it back to its original value when turning on the screen.