### PR TITLE
backend/libinput: fix WLR_HAS_DROIDIAN_EXTENSIONS check

### DIFF
--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -10,6 +10,8 @@
 #include "backend/libinput.h"
 #include "util/env.h"
 
+#include <wlr/config.h>
+
 #if WLR_HAS_DROIDIAN_EXTENSIONS
 #include <unistd.h>
 #endif // WLR_HAS_DROIDIAN_EXTENSIONS

--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,7 @@ endif
 
 features = {
 	'drm-backend': false,
+	'droidian-extensions': false,
 	'x11-backend': false,
 	'libinput-backend': false,
 	'hwcomposer-backend': false,
@@ -215,6 +216,10 @@ summary(features + internal_features, bool_yn: true)
 if get_option('examples')
 	subdir('examples')
 	subdir('tinywl')
+endif
+
+if get_option('droidian-extensions')
+	features += { 'droidian-extensions': true }
 endif
 
 pkgconfig = import('pkgconfig')


### PR DESCRIPTION
fixes warning: "WLR_HAS_DROIDIAN_EXTENSIONS" is not defined, evaluates to 0 [-Wundef]